### PR TITLE
generate address without access token

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ const WALLET_PASSWORD: &str = "Strong+Wallet+Pa55word";
 async fn main() -> Result<()> {
     dotenvy::dotenv().expect("Failed to load .env file");
     let username = std::env::var("USER_NAME").expect("USER_NAME must be set");
-    let password = std::env::var("USER_PASSWORD").expect("USER_PASSWORD must be set"); 
+    let password = std::env::var("USER_PASSWORD").expect("USER_PASSWORD must be set");
     
     // Replace with the SDK Configuration for your project. Get it from the dashboard: https://dashboard.cawaena.com
     let config = Config::from_json(r#"
@@ -53,6 +53,8 @@ async fn main() -> Result<()> {
             },
         }
     ]));
+    
+    // Select which network to use
     sdk.set_network(String::from("67a1f08edf55756bae21e7eb")).await.unwrap();
     
     // Set wallet password if not set


### PR DESCRIPTION
In case there were no networks set, the sdk tried to get these from the backend. Therefore, it needs an access token. We want this to work without on access token.

Check also the sdk changed related to these:  https://github.com/ETOSPHERES-Labs/cawaena-sdk/pull/60

Removed the `set_currency`.