### PR TITLE
chore: rename package name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Copy this file to .env and set the missing values
 AUTH_URL = "https://auth-etopay.etospheres.com"
-AUTH_CLIENT_ID = "cawaena"
+AUTH_CLIENT_ID = "builtin-client"
 AUTH_CLIENT_SECRET =
 
 USER_NAME = "testuser"

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Copy this file to .env and set the missing values
-AUTH_URL = "https://auth.cawaena.com"
+AUTH_URL = "https://auth-etopay.etospheres.com"
 AUTH_CLIENT_ID = "cawaena"
 AUTH_CLIENT_SECRET =
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "cawaena-sdk-quickstart-rs"
+name = "etopay-sdk-quickstart-rs"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-cawaena-sdk = { git = "https://github.com/ETOSPHERES-Labs/cawaena-sdk", branch = "main", package ="sdk" }
+etopay-sdk = { git = "https://github.com/ETOSPHERES-Labs/etopay-sdk", branch = "main", package ="etopay-sdk" }
 tokio = { version = "1", features = ["sync"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = { version = "1.0.140", default-features = false }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
 # Introduction
 
-This is a quickstart example of how to use the Cawaena SDK to create a new wallet and generate the first receiver address.
+This is a quickstart example of how to use the ETOPay SDK to create a new wallet and generate the first receiver address.
 
 ## Getting started
 
 - Copy the .env.example file to .env and set the missing values
-- Go to https://dashboard.cawaena.com and get the SDK configuration for you project
+- Go to https://etopayapp.etospheres.com and get the SDK configuration for you project
 - Set the SDK configuration in main.rs
 - Run the example with `cargo run`
 
@@ -15,7 +15,7 @@ This is a quickstart example of how to use the Cawaena SDK to create a new walle
 Curl snippet to get an access_token.
 
 ```bash
-curl -X POST "https://auth.cawaena.com/realms/<realm>/protocol/openid-connect/token" \
+curl -X POST "https://auth-etopay.etospheres.com/realms/<realm>/protocol/openid-connect/token" \
      -H "Content-Type: application/x-www-form-urlencoded" \
      -d "grant_type=password" \
      -d "scope=profile email openid" \

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 
 use std::path::Path;
-use cawaena_sdk::{core::{Config, Sdk}, types::newtypes::{EncryptionPin, PlainPassword}};
+use etopay_sdk::{core::{Config, Sdk}, types::newtypes::{EncryptionPin, PlainPassword}};
 mod utils;
 
 pub type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
     let username = std::env::var("USER_NAME").expect("USER_NAME must be set");
     let password = std::env::var("USER_PASSWORD").expect("USER_PASSWORD must be set");
     
-    // Replace with the SDK Configuration for your project. Get it from the dashboard: https://dashboard.cawaena.com
+    // Replace with the SDK Configuration for your project. Get it from the dashboard: https://etopayapp.etospheres.com
     let config = Config::from_json(r#"
     
     // Add your SDK configuration here

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use cawaena_sdk::types::newtypes::AccessToken;
+use etopay_sdk::types::newtypes::AccessToken;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
* After recent changes we renamed the sdk package name to `etopay-sdk`. 
* Renamed also other places like readme, urls