### PR TITLE
doc: updated readme to use dep from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-etopay-sdk = { git = "https://github.com/ETOSPHERES-Labs/etopay-sdk", branch = "release/0.14", package ="etopay-sdk" }
+etopay-sdk = { git = "https://github.com/ETOSPHERES-Labs/etopay-sdk", branch = "main", package ="etopay-sdk" }
 tokio = { version = "1", features = ["sync"] }
 serde = { version = "1.0", features = ["derive"] }
 reqwest = { version = "0.12", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ You can access the SDK by adding the following dependency to your `Cargo.toml` f
 [dependencies]
 etopay-sdk = { git = "https://github.com/ETOSPHERES-Labs/etopay-sdk", branch = "main"}
 ```
+or
+
+```toml
+[dependencies]
+etopay-sdk = "0.14.0-rc0"
+```
+
 
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ or
 etopay-sdk = "0.14.0-rc0"
 ```
 
+You can also add the dependency using
 
+```shell
+cargo add etopay-sdk
+```
 
 ## Getting started
 


### PR DESCRIPTION
Updated the description to use the ETOPay SDK dependency from crates.io as well.